### PR TITLE
Fix compatibility regressions from multiplayer support update

### DIFF
--- a/ui/dmt_mappinsubjectmanager.lua
+++ b/ui/dmt_mappinsubjectmanager.lua
@@ -12,7 +12,6 @@
 -- =======================================================================
 -- Imports
 -- =======================================================================
-include("SupportFunctions"); -- DeepCompare
 include("dmt_serialize"); -- Serialize and Deserialize
 
 -- =======================================================================
@@ -156,4 +155,65 @@ function BroadcastMapPinSubjects()
     -- Broadcast MapPinSubjects to all clients
     Network.BroadcastPlayerInfo();
     bUnbroadcastedChanges = false;
+end
+
+-- DeepCompare copied from SupportFunctions.lua
+-- Some other mods unintentionally remove this function from that file, so it is copied here instead
+-- ===========================================================================
+--  Recursively compare two tables (ignoring metatable)
+--  Original from: https://stackoverflow.com/questions/25922437/how-can-i-deep-compare-2-lua-tables-which-may-or-may-not-have-tables-as-keys
+--  ARGS:    table1        table one
+--           table2        table two
+--  RETURNS:    true if tables have the same content, false otherwise
+-- ===========================================================================
+function DeepCompare( table1, table2 )
+    local avoid_loops = {}
+
+    local function recurse(t1, t2)      
+        -- Compare value types
+        if type(t1) ~= type(t2) then return false; end
+
+        -- Compare simple values
+        if type(t1) ~= "table" then return (t1 == t2); end
+      
+        -- First, let's avoid looping forever.
+        if avoid_loops[t1] then return avoid_loops[t1] == t2; end
+        avoid_loops[t1] = t2;
+
+            -- Copy keys from t2
+        local t2keys = {}
+        local t2tablekeys = {}
+        for k, _ in pairs(t2) do
+            if type(k) == "table" then table.insert(t2tablekeys, k); end
+            t2keys[k] = true;
+        end
+
+        -- Iterate keys from t1
+        for k1, v1 in pairs(t1) do
+            local v2 = t2[k1]
+            if type(k1) == "table" then
+                -- if key is a table, we need to find an equivalent one.
+                local ok = false
+                for i, tk in ipairs(t2tablekeys) do
+                    if DeepCompare(k1, tk) and recurse(v1, t2[tk]) then
+                        table.remove(t2tablekeys, i)
+                        t2keys[tk] = nil
+                        ok = true
+                        break;
+                    end
+                end
+                if not ok then return false; end
+            else
+                -- t1 has a key which t2 doesn't have, fail.
+                if v2 == nil then return false; end
+                t2keys[k1] = nil
+                if not recurse(v1, v2) then return false; end
+            end
+        end
+        -- if t2 has a key which t1 doesn't have, fail.
+        if next(t2keys) then return false; end
+        return true;
+    end
+
+    return recurse(table1, table2);
 end


### PR DESCRIPTION
The code I submitted previously unfortunately broke compatibility with a few mods in an unexpected way. The issue lies in my use of `DeepCompare` from the `SupportFunctions.lua` file. Some other mods, notably Production Queue, completely replace this file with their own version. Production Queue, for instance, hasn't been updated since 2019, and the version of `SupportFunctions.lua` it has does not contain the `DeepCompare` function like the vanilla game does.

This function greatly helps with performance as it will skip serializing data unnecessarily, so removing it isn't a viable option. Instead, I believe the best option is to just copy the `DeepCompare` function over and remove the inclusion of `SupportFunctions.lua`.

A very similar option is to also copy the function over, but only use it if `DeepCompare` wasn't found. This can be accomplished by just wrapping the copied function in an `if not DeepCompare` statement. Would you prefer this or is the one in this pull request fine?

To clarify a bit, this issue isn't really with Detailed Map Tacks, but with others like Production Queue. It completely overwrites the original file with an outdated version that breaks not only this mod, but several other mods I use. My main motivation for fixing this issue is just that these mods worked together before my changes, and I don't want to break existing compatibility if it's not necessary.

Thanks for reading! I look forward to your response!